### PR TITLE
Catch JSON::ParserError on the directory search response

### DIFF
--- a/lib/omniauth/nusso/version.rb
+++ b/lib/omniauth/nusso/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Nusso
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/lib/omniauth/strategies/nusso.rb
+++ b/lib/omniauth/strategies/nusso.rb
@@ -98,7 +98,7 @@ module OmniAuth
               end
             end.compact
           ]
-        rescue AuthException
+        rescue AuthException, JSON::ParserError
           netid_user(net_id)
         end
     end

--- a/spec/omniauth/strategies/nusso_spec.rb
+++ b/spec/omniauth/strategies/nusso_spec.rb
@@ -172,4 +172,35 @@ __EOC__
       expect(last_request.env['omniauth.auth']['info']['email']).to eq('abc123@e.northwestern.edu')
     end
   end
+
+  context 'blank directory entry' do
+    before do
+      stub_request(:get, 'https://test.example.edu/agentless-websso/validateWebSSOToken')
+      .with(
+        headers: {
+          'Apikey' => 'test-consumer-key',
+          'Webssotoken' => 'success-token'
+        }
+      )
+      .to_return(body: %({"netid": "#{netid}"}))
+
+      stub_request(:get, 'https://test.example.edu/agentless-websso/validate-with-directory-search-response')
+      .with(
+        headers: {
+          'Apikey' => 'test-consumer-key',
+          'Webssotoken' => 'success-token'
+        }
+      )
+      .to_return(status: 200, body: '')
+
+      set_cookie('nusso=success-token')
+      get '/auth/nusso/callback'
+    end
+
+    it 'contains computed user info' do
+      expect(last_request.env['omniauth.auth']['uid']).to eq('abc123')
+      expect(last_request.env['omniauth.auth']['info']['name']).to eq('abc123')
+      expect(last_request.env['omniauth.auth']['info']['email']).to eq('abc123@e.northwestern.edu')
+    end
+  end
 end


### PR DESCRIPTION
## Description

The Agentless SSO API sometimes returns an empty body on calls to `validate-with-directory-search-response`, and this is preventing valid users from logging in. See https://github.com/nulib/repodev_planning_and_docs/issues/702

## Solution

* Catch `JSON::ParserError` along with `AuthException` to handle empty responses.
* Follow up with the IT Service Manager about the invalid empty response.